### PR TITLE
Damage Calc Feature Proposal: Bulk and Absolute-Power Calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 dist/
+package-lock.json

--- a/dmgcalc/index.html
+++ b/dmgcalc/index.html
@@ -292,9 +292,6 @@
                                             <span id="resultDamageL1"
                                                 >??? - ???%</span
                                             >
-                                            <span id="resultPowerL1">
-                                                ???  
-                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -310,9 +307,6 @@
                                             <span id="resultDamageL2"
                                                 >??? - ???%</span
                                             >
-                                            <span id="resultPowerL2">
-                                                ???  
-                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -328,9 +322,6 @@
                                             <span id="resultDamageL3"
                                                 >??? - ???%</span
                                             >
-                                            <span id="resultPowerL3">
-                                                ???
-                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -346,9 +337,6 @@
                                             <span id="resultDamageL4"
                                                 >??? - ???%</span
                                             >
-                                            <span id="resultPowerL4">
-                                                ???
-                                            </span>
                                         </div>
                                     </div>
                                 </div>
@@ -545,9 +533,6 @@
                                             <span id="resultDamageR1"
                                                 >??? - ???%</span
                                             >
-                                            <span id="resultPowerR1">
-                                            ???
-                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -563,9 +548,6 @@
                                             <span id="resultDamageR2"
                                                 >??? - ???%</span
                                             >
-                                            <span id="resultPowerR2">
-                                                ???
-                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -581,9 +563,6 @@
                                             <span id="resultDamageR3"
                                                 >??? - ???%</span
                                             >
-                                            <span id="resultPowerR3">
-                                                ???
-                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -599,9 +578,6 @@
                                             <span id="resultDamageR4"
                                                 >??? - ???%</span
                                             >
-                                            <span id="resultPowerR4">
-                                                ???
-                                            </span>
                                         </div>
                                     </div>
                                 </div>
@@ -1209,6 +1185,7 @@
                                 ><option value="4">4 hits</option
                                 ><option value="5">5 hits</option></select
                             >
+                            <span id="p1_move1_power" style="padding-left: 6px;">Power</span>
                         </div>
                         <div class="move2">
                             <select
@@ -1250,6 +1227,7 @@
                                 ><option value="4">4 hits</option
                                 ><option value="5">5 hits</option></select
                             >
+                            <span id="p1_move2_power" style="padding-left: 6px;">update</span>
                         </div>
                         <div class="move3">
                             <select
@@ -1291,6 +1269,7 @@
                                 ><option value="4">4 hits</option
                                 ><option value="5">5 hits</option></select
                             >
+                            <span id="p1_move3_power" style="padding-left: 6px;">Power</span>
                         </div>
                         <div class="move4">
                             <select
@@ -1332,6 +1311,7 @@
                                 ><option value="4">4 hits</option
                                 ><option value="5">5 hits</option></select
                             >
+                            <span id="p1_move4_power" style="padding-left: 6px;">Power</span>
                         </div>
                     </div>
                 </div>
@@ -2767,6 +2747,7 @@
                                 ><option value="4">4 hits</option
                                 ><option value="5">5 hits</option></select
                             >
+                            <span id="p2_move1_power" style="padding-left: 6px;">Power</span>
                         </div>
                         <div class="move2">
                             <select
@@ -2808,6 +2789,7 @@
                                 ><option value="4">4 hits</option
                                 ><option value="5">5 hits</option></select
                             >
+                            <span id="p2_move2_power" style="padding-left: 6px;">Power</span>
                         </div>
                         <div class="move3">
                             <select
@@ -2849,6 +2831,7 @@
                                 ><option value="4">4 hits</option
                                 ><option value="5">5 hits</option></select
                             >
+                            <span id="p2_move3_power" style="padding-left: 6px;">Power</span>
                         </div>
                         <div class="move4">
                             <select
@@ -2890,6 +2873,7 @@
                                 ><option value="4">4 hits</option
                                 ><option value="5">5 hits</option></select
                             >
+                            <span id="p2_move4_power" style="padding-left: 6px;">Power</span>
                         </div>
                     </div>
                 </div>

--- a/dmgcalc/index.html
+++ b/dmgcalc/index.html
@@ -294,7 +294,7 @@
                                             >
                                             <cell>
                                                 <span id="resultPowerL1">
-                                                    MaxPower  
+                                                    ???  
                                                 </span>
                                             </cell>
                                         </div>
@@ -314,7 +314,7 @@
                                             >
                                             <cell>
                                                 <span id="resultPowerL2">
-                                                    MaxPower  
+                                                    ???  
                                                 </span>
                                             </cell>
                                         </div>
@@ -334,7 +334,7 @@
                                             >
                                             <cell>
                                                 <span id="resultPowerL3">
-                                                    MaxPower 
+                                                    ??? 
                                                 </span>
                                             </cell>
                                         </div>
@@ -354,7 +354,7 @@
                                             >
                                             <cell>
                                                 <span id="resultPowerL4">
-                                                    MaxPower  
+                                                    ???  
                                                 </span>
                                             </cell>
                                         </div>
@@ -553,6 +553,11 @@
                                             <span id="resultDamageR1"
                                                 >??? - ???%</span
                                             >
+                                            <cell>
+                                                <span id="resultPowerR1">
+                                                    ??? 
+                                                </span>
+                                            </cell>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -568,6 +573,11 @@
                                             <span id="resultDamageR2"
                                                 >??? - ???%</span
                                             >
+                                            <cell>
+                                                <span id="resultPowerR2">
+                                                    ??? 
+                                                </span>
+                                            </cell>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -583,6 +593,11 @@
                                             <span id="resultDamageR3"
                                                 >??? - ???%</span
                                             >
+                                            <cell>
+                                                <span id="resultPowerR3">
+                                                    ??? 
+                                                </span>
+                                            </cell>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -598,6 +613,11 @@
                                             <span id="resultDamageR4"
                                                 >??? - ???%</span
                                             >
+                                            <cell>
+                                                <span id="resultPowerR4">
+                                                    ??? 
+                                                </span>
+                                            </cell>
                                         </div>
                                     </div>
                                 </div>
@@ -820,8 +840,7 @@
                                             ></select
                                         >
                                     </td>
-                                    <!-- TODO insert bulk calculation -->
-                                    <td>
+                                    <td class="phyBulk">
                                         PhyBulk
                                     </td>
                                 </tr>
@@ -937,8 +956,7 @@
                                             ></select
                                         >
                                     </td>
-                                    <!-- TODO insert bulk calculation -->
-                                    <td>
+                                    <td class="spBulk">
                                         SpBulk
                                     </td>
                                 </tr>
@@ -2380,8 +2398,7 @@
                                             ></select
                                         >
                                     </td>
-                                    <!-- TODO insert bulk calculation -->
-                                    <td>
+                                    <td class="phyBulk">
                                         PhyBulk
                                     </td>
                                 </tr>
@@ -2497,8 +2514,7 @@
                                             ></select
                                         >
                                     </td>
-                                    <!-- TODO insert bulk calculation -->
-                                    <td>
+                                    <td class="spBulk">
                                         SpBulk
                                     </td>
                                 </tr>

--- a/dmgcalc/index.html
+++ b/dmgcalc/index.html
@@ -292,6 +292,11 @@
                                             <span id="resultDamageL1"
                                                 >??? - ???%</span
                                             >
+                                            <cell>
+                                                <span id="resultPowerL1">
+                                                    MaxPower  
+                                                </span>
+                                            </cell>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -307,6 +312,11 @@
                                             <span id="resultDamageL2"
                                                 >??? - ???%</span
                                             >
+                                            <cell>
+                                                <span id="resultPowerL2">
+                                                    MaxPower  
+                                                </span>
+                                            </cell>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -322,6 +332,11 @@
                                             <span id="resultDamageL3"
                                                 >??? - ???%</span
                                             >
+                                            <cell>
+                                                <span id="resultPowerL3">
+                                                    MaxPower 
+                                                </span>
+                                            </cell>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -337,6 +352,11 @@
                                             <span id="resultDamageL4"
                                                 >??? - ???%</span
                                             >
+                                            <cell>
+                                                <span id="resultPowerL4">
+                                                    MaxPower  
+                                                </span>
+                                            </cell>
                                         </div>
                                     </div>
                                 </div>
@@ -451,6 +471,24 @@
                                                     >(56.3%)</span
                                                 ></span
                                             >
+                                        </div>
+                                        <div
+                                            class="big-text"
+                                            style="line-height: 30px;"
+                                        >
+                                            <div
+                                                style="
+                                                    width: 100px;
+                                                    display: inline-block;
+                                                "
+                                            >
+                                                Power:
+                                            </div>
+                                            <span
+                                                id="mainResultPower"
+                                                style="font-weight: initial;"
+                                                >Min-MaxPower
+                                            </span>
                                         </div>
                                         <div
                                             class="big-text"
@@ -782,6 +820,10 @@
                                             ></select
                                         >
                                     </td>
+                                    <!-- TODO insert bulk calculation -->
+                                    <td>
+                                        PhyBulk
+                                    </td>
                                 </tr>
                                 <tr
                                     class="sa gen-specific g2 g3 g4 g5 g6 g7 g8 g9"
@@ -894,6 +936,10 @@
                                                 >-6</option
                                             ></select
                                         >
+                                    </td>
+                                    <!-- TODO insert bulk calculation -->
+                                    <td>
+                                        SpBulk
                                     </td>
                                 </tr>
                                 <tr class="sl gen-specific g1 hide">
@@ -2334,6 +2380,10 @@
                                             ></select
                                         >
                                     </td>
+                                    <!-- TODO insert bulk calculation -->
+                                    <td>
+                                        PhyBulk
+                                    </td>
                                 </tr>
                                 <tr
                                     class="sa gen-specific g2 g3 g4 g5 g6 g7 g8 g9"
@@ -2446,6 +2496,10 @@
                                                 >-6</option
                                             ></select
                                         >
+                                    </td>
+                                    <!-- TODO insert bulk calculation -->
+                                    <td>
+                                        SpBulk
                                     </td>
                                 </tr>
                                 <tr class="sl gen-specific g1 hide">

--- a/dmgcalc/index.html
+++ b/dmgcalc/index.html
@@ -2968,6 +2968,10 @@
             ></script>
             <script
                 type="text/javascript"
+                src="/dmgcalc/js/bulkpowercalc.js"
+            ></script>
+            <script
+                type="text/javascript"
                 src="/dmgcalc/js/ko_chance.js"
             ></script>
             <script

--- a/dmgcalc/index.html
+++ b/dmgcalc/index.html
@@ -292,11 +292,9 @@
                                             <span id="resultDamageL1"
                                                 >??? - ???%</span
                                             >
-                                            <cell>
-                                                <span id="resultPowerL1">
-                                                    ???  
-                                                </span>
-                                            </cell>
+                                            <span id="resultPowerL1">
+                                                ???  
+                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -312,11 +310,9 @@
                                             <span id="resultDamageL2"
                                                 >??? - ???%</span
                                             >
-                                            <cell>
-                                                <span id="resultPowerL2">
-                                                    ???  
-                                                </span>
-                                            </cell>
+                                            <span id="resultPowerL2">
+                                                ???  
+                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -332,11 +328,9 @@
                                             <span id="resultDamageL3"
                                                 >??? - ???%</span
                                             >
-                                            <cell>
-                                                <span id="resultPowerL3">
-                                                    ??? 
-                                                </span>
-                                            </cell>
+                                            <span id="resultPowerL3">
+                                                ???
+                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -352,11 +346,9 @@
                                             <span id="resultDamageL4"
                                                 >??? - ???%</span
                                             >
-                                            <cell>
-                                                <span id="resultPowerL4">
-                                                    ???  
-                                                </span>
-                                            </cell>
+                                            <span id="resultPowerL4">
+                                                ???
+                                            </span>
                                         </div>
                                     </div>
                                 </div>
@@ -472,7 +464,7 @@
                                                 ></span
                                             >
                                         </div>
-                                        <div
+                                        <!-- <div
                                             class="big-text"
                                             style="line-height: 30px;"
                                         >
@@ -489,7 +481,7 @@
                                                 style="font-weight: initial;"
                                                 >Min-MaxPower
                                             </span>
-                                        </div>
+                                        </div> -->
                                         <div
                                             class="big-text"
                                             style="line-height: 30px;"
@@ -553,11 +545,9 @@
                                             <span id="resultDamageR1"
                                                 >??? - ???%</span
                                             >
-                                            <cell>
-                                                <span id="resultPowerR1">
-                                                    ??? 
-                                                </span>
-                                            </cell>
+                                            <span id="resultPowerR1">
+                                            ???
+                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -573,11 +563,9 @@
                                             <span id="resultDamageR2"
                                                 >??? - ???%</span
                                             >
-                                            <cell>
-                                                <span id="resultPowerR2">
-                                                    ??? 
-                                                </span>
-                                            </cell>
+                                            <span id="resultPowerR2">
+                                                ???
+                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -593,11 +581,9 @@
                                             <span id="resultDamageR3"
                                                 >??? - ???%</span
                                             >
-                                            <cell>
-                                                <span id="resultPowerR3">
-                                                    ??? 
-                                                </span>
-                                            </cell>
+                                            <span id="resultPowerR3">
+                                                ???
+                                            </span>
                                         </div>
                                         <div class="move-wrapper">
                                             <input
@@ -613,11 +599,9 @@
                                             <span id="resultDamageR4"
                                                 >??? - ???%</span
                                             >
-                                            <cell>
-                                                <span id="resultPowerR4">
-                                                    ??? 
-                                                </span>
-                                            </cell>
+                                            <span id="resultPowerR4">
+                                                ???
+                                            </span>
                                         </div>
                                     </div>
                                 </div>

--- a/dmgcalc/js/ap_calc.js
+++ b/dmgcalc/js/ap_calc.js
@@ -635,7 +635,8 @@ function calculateAll(rerender_surv_dd = true) {
   var p1 = new Pokemon($("#p1"), field);
   var p2 = new Pokemon($("#p2"), field);
   damageResults = calculateAllMoves(p1, p2, field);
-  powercalc(p1, p2, field, damageResults);
+  powercalc(p1, p2, field);
+  powercalc(p2, p1, field);
   var result,
     minDamage,
     maxDamage,

--- a/dmgcalc/js/ap_calc.js
+++ b/dmgcalc/js/ap_calc.js
@@ -1787,7 +1787,14 @@ $(".result-move").change(function () {
           "</span>"
       );
       $("#mainResultDamage").html(result.damageText);
-      $("#mainResultPower").html(result.powerText);
+      var moveId = $(this).attr("id");
+      var moveIdMatch = moveId && moveId.match(/^resultMove(L|R)(\d)$/);
+      var powerText = "";
+      if (moveIdMatch) {
+        var player = moveIdMatch[1] === "L" ? "p1" : "p2";
+        powerText = $("#" + player + "_move" + moveIdMatch[2] + "_power").text();
+      }
+      $("#mainResultPower").html(powerText);
       $("#mainResultKO").html(result.koChanceText);
       $("#damageValues").text("(" + result.damage.join(", ") + ")");
     }

--- a/dmgcalc/js/ap_calc.js
+++ b/dmgcalc/js/ap_calc.js
@@ -635,7 +635,7 @@ function calculateAll(rerender_surv_dd = true) {
   var p1 = new Pokemon($("#p1"), field);
   var p2 = new Pokemon($("#p2"), field);
   damageResults = calculateAllMoves(p1, p2, field);
-  powercalc(p1, p2, field);
+  powercalc(p1, p2, field, damageResults);
   var result,
     minDamage,
     maxDamage,

--- a/dmgcalc/js/ap_calc.js
+++ b/dmgcalc/js/ap_calc.js
@@ -1787,6 +1787,7 @@ $(".result-move").change(function () {
           "</span>"
       );
       $("#mainResultDamage").html(result.damageText);
+      $("#mainResultPower").html(result.powerText);
       $("#mainResultKO").html(result.koChanceText);
       $("#damageValues").text("(" + result.damage.join(", ") + ")");
     }

--- a/dmgcalc/js/ap_calc.js
+++ b/dmgcalc/js/ap_calc.js
@@ -636,7 +636,6 @@ function calculateAll(rerender_surv_dd = true) {
   var p2 = new Pokemon($("#p2"), field);
   damageResults = calculateAllMoves(p1, p2, field);
   powercalc(p1, p2, field);
-  powercalc(p2, p1, field);
   var result,
     minDamage,
     maxDamage,

--- a/dmgcalc/js/ap_calc.js
+++ b/dmgcalc/js/ap_calc.js
@@ -635,6 +635,7 @@ function calculateAll(rerender_surv_dd = true) {
   var p1 = new Pokemon($("#p1"), field);
   var p2 = new Pokemon($("#p2"), field);
   damageResults = calculateAllMoves(p1, p2, field);
+  powercalc(p1, p2, field);
   var result,
     minDamage,
     maxDamage,

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -1,0 +1,28 @@
+function powercalc(attacker, defender, field) {
+  //create dummy ditto
+  //give ditto defender ability, type, weight, dynamax
+  var dummy = new Pokemon($("#p1"));
+  dummy.ability = defender.ability;
+  dummy.isDynamax = defender.isDynamax;
+  dummy.type1 = defender.type1;
+  dummy.type2 = defender.type2;
+  dummy.weight = defender.weight;
+  dummy.HPEVs = 0;
+  dummy.baseStats = { at: 48, df: 48, sa: 48, sd: 48, sp: 48 };
+  dummy.boosts = { at: 0, df: 0, sa: 0, sd: 0, sp: 0 };
+  dummy.curHP = 123;
+  dummy.evs = { at: 0, df: 0, sa: 0, sd: 0, sp: 0, hp: 0 };
+  dummy.item = "";
+  dummy.ivs = { at: 31, df: 31, sa: 31, sd: 31, sp: 31, hp: 31 };
+  dummy.level = 50;
+  dummy.maxHP = 123;
+  dummy.name = "Ditto";
+  dummy.nature = "Hardy";
+  dummy.rawStats = { at: 68, df: 68, sa: 68, sd: 68, sp: 68 };
+  dummy.stats = {df: 68, sd: 68, sp: 68, at: 68, sa: 68};
+  dummy.toxicCounter = 0;
+  let damageResults = calculateAllMoves(attacker, dummy, field);
+  console.log(damageResults);
+
+  //output result
+}

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -1,5 +1,6 @@
-function powercalc(attacker, defender, field, realResults) {
-  //create dummy ditto
+function powercalc(attacker, defender, field) {
+  //create new pokemon based on p1
+  //replace most props with ditto props
   //give ditto defender ability, type, weight, dynamax
   var dummy = new Pokemon($("#p1"));
   dummy.ability = defender.ability;
@@ -7,9 +8,10 @@ function powercalc(attacker, defender, field, realResults) {
   dummy.type1 = defender.type1;
   dummy.type2 = defender.type2;
   dummy.weight = defender.weight;
+  dummy.status = defender.status;
   dummy.HPEVs = 0;
   dummy.baseStats = { at: 48, df: 48, sa: 48, sd: 48, sp: 48 };
-  dummy.boosts = { at: 0, df: 0, sa: 0, sd: 0, sp: 0 };
+  dummy.boosts = { at: 0, df: 0, sa: 0, sd: 0, sp: defender.boosts.sp };
   dummy.curHP = 123;
   dummy.evs = { at: 0, df: 0, sa: 0, sd: 0, sp: 0, hp: 0 };
   dummy.item = "";
@@ -18,17 +20,25 @@ function powercalc(attacker, defender, field, realResults) {
   dummy.maxHP = 123;
   dummy.name = "Ditto";
   dummy.nature = "Hardy";
-  dummy.rawStats = { at: 68, df: 68, sa: 68, sd: 68, sp: 68 };
+  dummy.rawStats = { at: 68, df: 68, sa: 68, sd: 68, sp: defender.rawStats.sp };
   dummy.stats = {df: 68, sd: 68, sp: 68, at: 68, sa: 68};
   dummy.toxicCounter = 0;
-
+  //console.log(dummy);
+  //set aside attacker move powers here
   let dummyResults = calculateAllMoves(attacker, dummy, field);
-  let minPower = dummyResults[0][0].damage[0];
-  //dummyresults[p1attacker,p2attacker][move slot].damage[damage roll position]
-  //console.log(minPower);
+  //dummyresults[0attackermoves,1dummymoves][move slot].damage[damage roll position]
+  let minPowers = [0,0,0,0];
+  for (move in dummyResults[0]) {
+    minPowers[move] = dummyResults[0][move].damage[0];
+  }
+  //TODO render(minPowers);
 
 
+  //set dummy status to healthy and non dynamax for accurate bulk calc
+  dummy.status = "Healthy";
+  dummy.isDynamax = false;
 
+  //set dummy moves 0 and 1 to be hyperbeam and giga impact for attacker bulk calculation
   let dumSpecAttack = dummy.moves[0];
   dumSpecAttack.bp = 999
   dumSpecAttack.category = "Special"
@@ -46,19 +56,27 @@ function powercalc(attacker, defender, field, realResults) {
   dumSpecAttack.useMax = false;
   dumSpecAttack.zp = 999;
 
-  let dumPhysAttack = dummy.moves[1] = dumSpecAttack;
+  let dumPhysAttack = dummy.moves[1] = {...dumSpecAttack};
   dumPhysAttack.category = "Physical";
   dumPhysAttack.displayName = "Giga Impact";
   dumPhysAttack.name = "Giga Impact";
 
-
-  console.log(dummy.moves[1]);
+  //set aside dummy attacks min power for bulk calc
   dummyResults = calculateAllMoves(attacker, dummy, field);
-  console.log(dummyResults);
+  let stSpDamage = dummyResults[1][0].damage[0];
+  let stPhysDamage = dummyResults[1][1].damage[0];
 
-
-  let defenderbulk = minPower*defender.maxHP/realResults[0][0].damage[0];
-  //console.log(defenderbulk);
+  //dummy attack damage vs standard ditto min roll = 374 (scales bulk to equal power)
+  let spBulk = Math.round(374*attacker.maxHP/stSpDamage);
+  let physBulk = Math.round(374*attacker.maxHP/stPhysDamage);
+  console.log(attacker.name, spBulk, physBulk);
 
   //output result
 }
+
+/*
+TODO
+-field effects on attacker side apply to both pokemon (screens)
+-weird miscalculation of bulk on pokemon change
+
+*/

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -1,7 +1,7 @@
 function createDummy(pokemon) {
   //create new pokemon based on p1
   var dummy = new Pokemon($("#p1"));
-  //give it the desired pokemon ability, type, weight, dynamax
+  //give it the desired pokemon ability, type, weight, dynamax, speed
   dummy.ability = pokemon.ability;
   dummy.isDynamax = pokemon.isDynamax;
   dummy.type1 = pokemon.type1;

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -1,4 +1,4 @@
-function powercalc(attacker, defender, field) {
+function powercalc(attacker, defender, field, realResults) {
   //create dummy ditto
   //give ditto defender ability, type, weight, dynamax
   var dummy = new Pokemon($("#p1"));
@@ -21,8 +21,44 @@ function powercalc(attacker, defender, field) {
   dummy.rawStats = { at: 68, df: 68, sa: 68, sd: 68, sp: 68 };
   dummy.stats = {df: 68, sd: 68, sp: 68, at: 68, sa: 68};
   dummy.toxicCounter = 0;
-  let damageResults = calculateAllMoves(attacker, dummy, field);
-  console.log(damageResults);
+
+  let dummyResults = calculateAllMoves(attacker, dummy, field);
+  let minPower = dummyResults[0][0].damage[0];
+  //dummyresults[p1attacker,p2attacker][move slot].damage[damage roll position]
+  //console.log(minPower);
+
+
+
+  let dumSpecAttack = dummy.moves[0];
+  dumSpecAttack.bp = 999
+  dumSpecAttack.category = "Special"
+  dumSpecAttack.displayName = "Hyper Beam"
+  dumSpecAttack.hasSecondaryEffect = false;
+  dumSpecAttack.hits = 1;
+  dumSpecAttack.isCrit = false;
+  dumSpecAttack.isMax = false;
+  dumSpecAttack.isSpread = false;
+  dumSpecAttack.isZ = false;
+  dumSpecAttack.name = "Hyper Beam";
+  dumSpecAttack.overrides = {basePower: 999, type: "???"};
+  dumSpecAttack.species = "Ditto";
+  dumSpecAttack.type = "???";
+  dumSpecAttack.useMax = false;
+  dumSpecAttack.zp = 999;
+
+  let dumPhysAttack = dummy.moves[1] = dumSpecAttack;
+  dumPhysAttack.category = "Physical";
+  dumPhysAttack.displayName = "Giga Impact";
+  dumPhysAttack.name = "Giga Impact";
+
+
+  console.log(dummy.moves[1]);
+  dummyResults = calculateAllMoves(attacker, dummy, field);
+  console.log(dummyResults);
+
+
+  let defenderbulk = minPower*defender.maxHP/realResults[0][0].damage[0];
+  //console.log(defenderbulk);
 
   //output result
 }

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -1,17 +1,16 @@
-function powercalc(attacker, defender, field) {
+function createDummy(pokemon) {
   //create new pokemon based on p1
-  //replace most props with ditto props
-  //give ditto defender ability, type, weight, dynamax
   var dummy = new Pokemon($("#p1"));
-  dummy.ability = defender.ability;
-  dummy.isDynamax = defender.isDynamax;
-  dummy.type1 = defender.type1;
-  dummy.type2 = defender.type2;
-  dummy.weight = defender.weight;
-  dummy.status = defender.status;
+  //give it the desired pokemon ability, type, weight, dynamax
+  dummy.ability = pokemon.ability;
+  dummy.isDynamax = pokemon.isDynamax;
+  dummy.type1 = pokemon.type1;
+  dummy.type2 = pokemon.type2;
+  dummy.weight = pokemon.weight;
+  dummy.status = pokemon.status;
   dummy.HPEVs = 0;
   dummy.baseStats = { at: 48, df: 48, sa: 48, sd: 48, sp: 48 };
-  dummy.boosts = { at: 0, df: 0, sa: 0, sd: 0, sp: defender.boosts.sp };
+  dummy.boosts = { at: 0, df: 0, sa: 0, sd: 0, sp: pokemon.boosts.sp };
   dummy.curHP = 123;
   dummy.evs = { at: 0, df: 0, sa: 0, sd: 0, sp: 0, hp: 0 };
   dummy.item = "";
@@ -20,25 +19,11 @@ function powercalc(attacker, defender, field) {
   dummy.maxHP = 123;
   dummy.name = "Ditto";
   dummy.nature = "Hardy";
-  dummy.rawStats = { at: 68, df: 68, sa: 68, sd: 68, sp: defender.rawStats.sp };
+  dummy.rawStats = { at: 68, df: 68, sa: 68, sd: 68, sp: pokemon.rawStats.sp };
   dummy.stats = {df: 68, sd: 68, sp: 68, at: 68, sa: 68};
   dummy.toxicCounter = 0;
-  //console.log(dummy);
-  //set aside attacker move powers here
-  let dummyResults = calculateAllMoves(attacker, dummy, field);
-  //dummyresults[0attackermoves,1dummymoves][move slot].damage[damage roll position]
-  let minPowers = [0,0,0,0];
-  for (move in dummyResults[0]) {
-    minPowers[move] = dummyResults[0][move].damage[0];
-  }
-  //TODO render(minPowers);
 
-
-  //set dummy status to healthy and non dynamax for accurate bulk calc
-  dummy.status = "Healthy";
-  dummy.isDynamax = false;
-
-  //set dummy moves 0 and 1 to be hyperbeam and giga impact for attacker bulk calculation
+  //set dummy moves 0 and 1 to be hyperbeam and giga impact for p1 bulk calculation
   let dumSpecAttack = dummy.moves[0];
   dumSpecAttack.bp = 999
   dumSpecAttack.category = "Special"
@@ -61,22 +46,71 @@ function powercalc(attacker, defender, field) {
   dumPhysAttack.displayName = "Giga Impact";
   dumPhysAttack.name = "Giga Impact";
 
-  //set aside dummy attacks min power for bulk calc
-  dummyResults = calculateAllMoves(attacker, dummy, field);
-  let stSpDamage = dummyResults[1][0].damage[0];
-  let stPhysDamage = dummyResults[1][1].damage[0];
+  return dummy;
+}
+
+
+function getPowers(results, side) {
+  //results[0p1moves,1p2moves][move slot].damage[damage roll position, min - max]
+  let powers = [0,0,0,0];
+  for (move in results[side]) {
+    powers[move] = results[side][move].damage[0];
+  }
+  return powers;
+}
+
+//due to field effects, use opposite side position in results to get relevant damage
+function calcBulk(pokemon, results, oppside) {
+  let SpDamage = results[oppside][0].damage[0];
+  let PhysDamage = results[oppside][1].damage[0];
 
   //dummy attack damage vs standard ditto min roll = 374 (scales bulk to equal power)
-  let spBulk = Math.round(374*attacker.maxHP/stSpDamage);
-  let physBulk = Math.round(374*attacker.maxHP/stPhysDamage);
-  console.log(attacker.name, spBulk, physBulk);
+  let spBulk = Math.round(374*pokemon.maxHP/SpDamage);
+  let physBulk = Math.round(374*pokemon.maxHP/PhysDamage);
+  return [physBulk, spBulk];
+}
+
+function powercalc(p1, p2, field) {
+  //create dummy versions of p1 and p2
+  let p1Dummy = createDummy(p1);
+  let p2Dummy = createDummy(p2);
+  //console.log(dummy);
+  //calc and set aside move powers here
+  //field effects are sided so need to calculate both directions
+  let p1Results = calculateAllMoves(p1, p2Dummy, field);
+  let p2Results = calculateAllMoves(p1Dummy, p2, field);
+  
+  let p1Powers = getPowers(p1Results, 0);
+  let p2Powers = getPowers(p2Results, 1);
+
+  //TODO render(minPowers);
+
+
+  //set dummy status to healthy and non dynamax for accurate bulk calc
+  p1Dummy.status = "Healthy";
+  p1Dummy.isDynamax = false;
+  p2Dummy.status = "Healthy";
+  p2Dummy.isDynamax = false;
+  
+  //PROBLEM: helping hand affects bulk calculation
+  //field is not an editable object, constructor gets from html state
+
+  //redo damage calcs for bulk calc
+  p1Results = calculateAllMoves(p1, p2Dummy, field);
+  p2Results = calculateAllMoves(p1Dummy, p2, field);
+
+  p1Bulk = calcBulk(p1, p1Results, 1);
+  p2Bulk = calcBulk(p2, p2Results, 0);
+
+  console.log(1, p1.name, p1Bulk);
+  console.log(2, p2.name, p2Bulk);
 
   //output result
 }
 
 /*
 TODO
--field effects on attacker side apply to both pokemon (screens)
+-field effects on p1 side apply to both pokemon (screens)
 -weird miscalculation of bulk on pokemon change
 
 */

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -1,6 +1,6 @@
 function createDummy(pokemon) {
   //create new pokemon based on p1
-  var dummy = new Pokemon($("#p1"));
+  var dummy = new Pokemon($('#p1'));
   //give it the desired pokemon ability, type, weight, dynamax, speed
   dummy.ability = pokemon.ability;
   dummy.isDynamax = pokemon.isDynamax;
@@ -13,50 +13,49 @@ function createDummy(pokemon) {
   dummy.boosts = { at: 0, df: 0, sa: 0, sd: 0, sp: pokemon.boosts.sp };
   dummy.curHP = 123;
   dummy.evs = { at: 0, df: 0, sa: 0, sd: 0, sp: 0, hp: 0 };
-  dummy.item = "";
+  dummy.item = '';
   dummy.ivs = { at: 31, df: 31, sa: 31, sd: 31, sp: 31, hp: 31 };
   dummy.level = 50;
   dummy.maxHP = 123;
-  dummy.name = "Ditto";
-  dummy.nature = "Hardy";
+  dummy.name = 'Ditto';
+  dummy.nature = 'Hardy';
   dummy.rawStats = { at: 68, df: 68, sa: 68, sd: 68, sp: pokemon.rawStats.sp };
-  dummy.stats = {df: 68, sd: 68, sp: 68, at: 68, sa: 68};
+  dummy.stats = { df: 68, sd: 68, sp: 68, at: 68, sa: 68 };
   dummy.toxicCounter = 0;
 
   return dummy;
 }
 
 function setDummyMoves(dummy) {
-    //set dummy moves 0 and 1 to be hyperhyperbeam and gigagiga impact for p1 bulk calculation
-    let dumSpecAttack = dummy.moves[0];
-    dumSpecAttack.bp = 999
-    dumSpecAttack.category = "Special"
-    dumSpecAttack.displayName = "Hyper Beam"
-    dumSpecAttack.hasSecondaryEffect = false;
-    dumSpecAttack.hits = 1;
-    dumSpecAttack.isCrit = false;
-    dumSpecAttack.isMax = false;
-    dumSpecAttack.isSpread = false;
-    dumSpecAttack.isZ = false;
-    dumSpecAttack.name = "Hyper Beam";
-    dumSpecAttack.overrides = {basePower: 999, type: "???"};
-    dumSpecAttack.species = "Ditto";
-    dumSpecAttack.type = "???";
-    dumSpecAttack.useMax = false;
-    dumSpecAttack.zp = 999;
-  
-    let dumPhysAttack = dummy.moves[1] = {...dumSpecAttack};
-    dumPhysAttack.category = "Physical";
-    dumPhysAttack.displayName = "Giga Impact";
-    dumPhysAttack.name = "Giga Impact";
+  //set dummy moves 0 and 1 to be hyperhyperbeam and gigagiga impact for p1 bulk calculation
+  let dumSpecAttack = dummy.moves[0];
+  dumSpecAttack.bp = 999;
+  dumSpecAttack.category = 'Special';
+  dumSpecAttack.displayName = 'Hyper Beam';
+  dumSpecAttack.hasSecondaryEffect = false;
+  dumSpecAttack.hits = 1;
+  dumSpecAttack.isCrit = false;
+  dumSpecAttack.isMax = false;
+  dumSpecAttack.isSpread = false;
+  dumSpecAttack.isZ = false;
+  dumSpecAttack.name = 'Hyper Beam';
+  dumSpecAttack.overrides = { basePower: 999, type: '???' };
+  dumSpecAttack.species = 'Ditto';
+  dumSpecAttack.type = '???';
+  dumSpecAttack.useMax = false;
+  dumSpecAttack.zp = 999;
 
-    return dummy;
+  let dumPhysAttack = (dummy.moves[1] = { ...dumSpecAttack });
+  dumPhysAttack.category = 'Physical';
+  dumPhysAttack.displayName = 'Giga Impact';
+  dumPhysAttack.name = 'Giga Impact';
+
+  return dummy;
 }
-
 
 function getPowers(results, side) {
   //results[0p1moves,1p2moves][move slot].damage[damage roll position, min - max]
-  let powers = [0,0,0,0];
+  let powers = [0, 0, 0, 0];
   for (move in results[side]) {
     powers[move] = results[side][move].damage[0];
   }
@@ -69,16 +68,16 @@ function calcBulk(pokemon, results, oppside) {
   let physDamage = results[oppside][1].damage[0];
 
   //dummy attack damage vs standard ditto min roll = 374 (scales bulk to equal power)
-  let spBulk = Math.round(374*pokemon.maxHP/spDamage);
-  let physBulk = Math.round(374*pokemon.maxHP/physDamage);
+  let spBulk = Math.round((374 * pokemon.maxHP) / spDamage);
+  let physBulk = Math.round((374 * pokemon.maxHP) / physDamage);
   return [physBulk, spBulk];
 }
 
 function renderPowers(p1Powers, p2Powers) {
-  var resultLocations = [[], []]
+  var resultLocations = [[], []];
   for (var i = 0; i < 4; i++) {
-      resultLocations[0].push('#resultPowerL' + (i + 1));
-      resultLocations[1].push('#resultPowerR' + (i + 1));
+    resultLocations[0].push('#resultPowerL' + (i + 1));
+    resultLocations[1].push('#resultPowerR' + (i + 1));
   }
 
   for (move in resultLocations[0]) {
@@ -90,10 +89,10 @@ function renderPowers(p1Powers, p2Powers) {
 }
 
 function renderBulk(p1Bulk, p2Bulk) {
-  $("#p1 .phyBulk").text(p1Bulk[0]);
-  $("#p1 .spBulk").text(p1Bulk[1]);
-  $("#p2 .phyBulk").text(p2Bulk[0]);
-  $("#p2 .spBulk").text(p2Bulk[1]);
+  $('#p1 .phyBulk').text(p1Bulk[0]);
+  $('#p1 .spBulk').text(p1Bulk[1]);
+  $('#p2 .phyBulk').text(p2Bulk[0]);
+  $('#p2 .spBulk').text(p2Bulk[1]);
 }
 
 function powercalc(p1, p2, field) {
@@ -104,20 +103,20 @@ function powercalc(p1, p2, field) {
   //field effects are sided so need to calculate both directions
   let p1Results = calculateAllMoves(p1, p2Dummy, field);
   let p2Results = calculateAllMoves(p1Dummy, p2, field);
-  
+
   let p1Powers = getPowers(p1Results, 0);
   let p2Powers = getPowers(p2Results, 1);
   renderPowers(p1Powers, p2Powers);
 
   //set dummy status to healthy and non dynamax for accurate bulk calc
-  p1Dummy.status = "Healthy";
+  p1Dummy.status = 'Healthy';
   p1Dummy.isDynamax = false;
-  p2Dummy.status = "Healthy";
+  p2Dummy.status = 'Healthy';
   p2Dummy.isDynamax = false;
   //custom moves don't play nice with dynamax so remove dummy dynamax before setting moves for bulk calc
   p1Dummy = setDummyMoves(p1Dummy);
   p2Dummy = setDummyMoves(p2Dummy);
-  
+
   //PROBLEM: helping hand affects bulk calculation
   //field is not an editable object, constructor gets from html state
 

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -83,6 +83,9 @@ function powercalc(p1, p2, field) {
   let p1Powers = getPowers(p1Results, 0);
   let p2Powers = getPowers(p2Results, 1);
 
+  console.log(1, p1Powers);
+  console.log(2, p2Powers);
+
   //TODO render(minPowers);
 
 
@@ -102,8 +105,8 @@ function powercalc(p1, p2, field) {
   p1Bulk = calcBulk(p1, p1Results, 1);
   p2Bulk = calcBulk(p2, p2Results, 0);
 
-  console.log(1, p1.name, p1Bulk);
-  console.log(2, p2.name, p2Bulk);
+  // console.log(1, p1.name, p1Bulk);
+  // console.log(2, p2.name, p2Bulk);
 
   //output result
 }

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -1,13 +1,22 @@
 //TODO separate bulk calc dummy from power calc dummy, don't want properties of the target to affect the power rating of the attack
 
+function copyTypesAndTera(dummy, pokemon) {
+  dummy.type1 = pokemon.type1;
+  dummy.type2 = pokemon.type2;
+  if (pokemon.teraType) {
+    dummy.teraType = pokemon.teraType;
+  } else {
+    delete dummy.teraType;
+  }
+}
+
 function createBulkDummy(pokemon) {
   //create new pokemon based on p1
   var dummy = new Pokemon($('#p1'));
   //give it the desired pokemon ability, type, weight, dynamax, speed
   dummy.ability = pokemon.ability;
   dummy.isDynamax = pokemon.isDynamax;
-  dummy.type1 = pokemon.type1;
-  dummy.type2 = pokemon.type2;
+  copyTypesAndTera(dummy, pokemon);
   dummy.weight = pokemon.weight;
   dummy.status = pokemon.status;
   dummy.HPEVs = 0;
@@ -34,8 +43,10 @@ function createPowerDummy(pokemon) {
   //give it the desired pokemon ability, type, weight, dynamax, speed
   dummy.ability = pokemon.ability;
   dummy.isDynamax = pokemon.isDynamax;
+  // Neutral defender: no matchup effectiveness. STAB/Tera/boosts come from the real attacker (p1/p2).
   dummy.type1 = '???';
   dummy.type2 = '???';
+  delete dummy.teraType;
   dummy.weight = pokemon.weight;
   dummy.status = pokemon.status;
   dummy.HPEVs = 0;

--- a/dmgcalc/js/bulkpowercalc.js
+++ b/dmgcalc/js/bulkpowercalc.js
@@ -1,4 +1,6 @@
-function createDummy(pokemon) {
+//TODO separate bulk calc dummy from power calc dummy, don't want properties of the target to affect the power rating of the attack
+
+function createBulkDummy(pokemon) {
   //create new pokemon based on p1
   var dummy = new Pokemon($('#p1'));
   //give it the desired pokemon ability, type, weight, dynamax, speed
@@ -26,8 +28,36 @@ function createDummy(pokemon) {
   return dummy;
 }
 
+function createPowerDummy(pokemon) {
+  //create new dummy based on input pokemon
+  var dummy = new Pokemon($('#p1'));
+  //give it the desired pokemon ability, type, weight, dynamax, speed
+  dummy.ability = pokemon.ability;
+  dummy.isDynamax = pokemon.isDynamax;
+  dummy.type1 = '???';
+  dummy.type2 = '???';
+  dummy.weight = pokemon.weight;
+  dummy.status = pokemon.status;
+  dummy.HPEVs = 0;
+  dummy.baseStats = { at: 48, df: 48, sa: 48, sd: 48, sp: 48 };
+  dummy.boosts = { at: 0, df: 0, sa: 0, sd: 0, sp: pokemon.boosts.sp };
+  dummy.curHP = 123;
+  dummy.evs = { at: 0, df: 0, sa: 0, sd: 0, sp: 0, hp: 0 };
+  dummy.item = '';
+  dummy.ivs = { at: 31, df: 31, sa: 31, sd: 31, sp: 31, hp: 31 };
+  dummy.level = 50;
+  dummy.maxHP = 123;
+  dummy.name = 'Ditto';
+  dummy.nature = 'Hardy';
+  dummy.rawStats = { at: 68, df: 68, sa: 68, sd: 68, sp: pokemon.rawStats.sp };
+  dummy.stats = { df: 68, sd: 68, sp: 68, at: 68, sa: 68 };
+  dummy.toxicCounter = 0;
+
+  return dummy;
+}
+
 function setDummyMoves(dummy) {
-  //set dummy moves 0 and 1 to be hyperhyperbeam and gigagiga impact for p1 bulk calculation
+  //set dummy moves 0 and 1 to be hyperhyperbeam and gigagiga impact for bulk calculation
   let dumSpecAttack = dummy.moves[0];
   dumSpecAttack.bp = 999;
   dumSpecAttack.category = 'Special';
@@ -76,14 +106,14 @@ function calcBulk(pokemon, results, oppside) {
 function renderPowers(p1Powers, p2Powers) {
   var resultLocations = [[], []];
   for (var i = 0; i < 4; i++) {
-    resultLocations[0].push('#resultPowerL' + (i + 1));
-    resultLocations[1].push('#resultPowerR' + (i + 1));
+    resultLocations[0].push('#p1_move' + (i + 1) + '_power');
+    resultLocations[1].push('#p2_move' + (i + 1) + '_power');
   }
 
-  for (move in resultLocations[0]) {
+  for (var move = 0; move < resultLocations[0].length; move++) {
     $(resultLocations[0][move]).text(p1Powers[move]);
   }
-  for (move in resultLocations[1]) {
+  for (var move = 0; move < resultLocations[1].length; move++) {
     $(resultLocations[1][move]).text(p2Powers[move]);
   }
 }
@@ -97,32 +127,35 @@ function renderBulk(p1Bulk, p2Bulk) {
 
 function powercalc(p1, p2, field) {
   //create dummy versions of p1 and p2
-  let p1Dummy = createDummy(p1);
-  let p2Dummy = createDummy(p2);
+  let p1BulkDummy = createBulkDummy(p1);
+  let p2BulkDummy = createBulkDummy(p2);
+  //create dummy versions of p1 and p2
+  let p1PowerDummy = createPowerDummy(p1);
+  let p2PowerDummy = createPowerDummy(p2);
   //calc and set aside move powers here
   //field effects are sided so need to calculate both directions
-  let p1Results = calculateAllMoves(p1, p2Dummy, field);
-  let p2Results = calculateAllMoves(p1Dummy, p2, field);
+  let p1PowerResults = calculateAllMoves(p1, p2PowerDummy, field);
+  let p2PowerResults = calculateAllMoves(p1PowerDummy, p2, field);
 
-  let p1Powers = getPowers(p1Results, 0);
-  let p2Powers = getPowers(p2Results, 1);
+  let p1Powers = getPowers(p1PowerResults, 0);
+  let p2Powers = getPowers(p2PowerResults, 1);
   renderPowers(p1Powers, p2Powers);
 
   //set dummy status to healthy and non dynamax for accurate bulk calc
-  p1Dummy.status = 'Healthy';
-  p1Dummy.isDynamax = false;
-  p2Dummy.status = 'Healthy';
-  p2Dummy.isDynamax = false;
+  p1BulkDummy.status = 'Healthy';
+  p1BulkDummy.isDynamax = false;
+  p2BulkDummy.status = 'Healthy';
+  p2BulkDummy.isDynamax = false;
   //custom moves don't play nice with dynamax so remove dummy dynamax before setting moves for bulk calc
-  p1Dummy = setDummyMoves(p1Dummy);
-  p2Dummy = setDummyMoves(p2Dummy);
+  p1BulkDummy = setDummyMoves(p1BulkDummy);
+  p2BulkDummy = setDummyMoves(p2BulkDummy);
 
   //PROBLEM: helping hand affects bulk calculation
   //field is not an editable object, constructor gets from html state
 
   //redo damage calcs for bulk calc
-  p1Results = calculateAllMoves(p1, p2Dummy, field);
-  p2Results = calculateAllMoves(p1Dummy, p2, field);
+  p1Results = calculateAllMoves(p1, p2BulkDummy, field);
+  p2Results = calculateAllMoves(p1BulkDummy, p2, field);
 
   let p1Bulk = calcBulk(p1, p1Results, 1);
   let p2Bulk = calcBulk(p2, p2Results, 0);

--- a/dmgcalc/pikalytics_calc_styles.css
+++ b/dmgcalc/pikalytics_calc_styles.css
@@ -8,8 +8,8 @@
 #surv_button_loader {
   display: inline-block;
   position: relative;
-  top:-8px;
-  left:-8px;
+  top: -8px;
+  left: -8px;
 }
 #surv_button_loader div {
   box-sizing: border-box;
@@ -38,4 +38,7 @@
   100% {
     transform: rotate(360deg);
   }
+}
+.move-wrapper cell {
+  padding-left: 5px;
 }

--- a/dmgcalc/pikalytics_calc_styles.css
+++ b/dmgcalc/pikalytics_calc_styles.css
@@ -42,3 +42,9 @@
 .move-wrapper cell {
   padding-left: 5px;
 }
+.phyBulk {
+  padding-left: 6px;
+}
+.spBulk {
+  padding-left: 6px;
+}


### PR DESCRIPTION
Hi Pikalytics / @GriffinLedingham ! Big fan of the site and had an idea for the damage calc that I think would help players.

I've always disliked that there hasn't been an absolute value calculated for Pokémon bulk and move powers. Instead, the values are hidden by being split up between HP and defense stats for bulk, and move power, attack stat, typing, etc. for absolute power.

My feature for the damage calculator is to calculate a visible value for these properties and to put them on the same scale (eg: a Pokémon that can inflict 100 absolute damage will KO a Pokémon with 100 bulk). This could help players deal with situations that they haven't planned calcs for by giving them a more concrete sense of how strong their moves are and how bulky an opponent is.

The pull request I am submitting shows the feature working for the most part. Abs-power is calculated and shown next to each move's percentage damage done and bulk is shown next to the Pokémon's defense and sp-defense stats.

Some known issues: Conditions such as screens, friend guard, and helping hand affect both move power and bulk values when they should only affect one or the other (mainly due to the field object being uneditable). Adding an abs-power field to the central move readout would involve altering the 'results' object and accompanying functions and I'm not sure if changing them might break compatibility with the upstream calculator source code.

Would be happy to answer any questions about how the values are derived. Let me know if you think this is a feature worth working on.